### PR TITLE
Improve interface of `ContractInstance.__call__`

### DIFF
--- a/examples/ram/ram.py
+++ b/examples/ram/ram.py
@@ -155,9 +155,10 @@ def execute_command(input_line: str):
             )
             )
 
-        R_inst("withdraw",
-               outputs=outputs,
-               merkle_root=mt.root, merkle_proof=mt.prove_leaf(leaf_index))
+        R_inst("withdraw", outputs=outputs)(
+            merkle_root=mt.root,
+            merkle_proof=mt.prove_leaf(leaf_index)
+        )
 
         print("Done")
     elif action == "write":
@@ -174,11 +175,11 @@ def execute_command(input_line: str):
         if leaf_index not in range(len(R_inst.data_expanded)):
             raise ValueError("Invalid leaf index")
 
-        result = R_inst("write",
-                        merkle_root=mt.root,
-                        new_value=new_value,
-                        merkle_proof=mt.prove_leaf(leaf_index)
-                        )
+        result = R_inst("write")(
+            merkle_root=mt.root,
+            new_value=new_value,
+            merkle_proof=mt.prove_leaf(leaf_index)
+        )
 
         assert len(result) == 1
 

--- a/examples/ram/ram.py
+++ b/examples/ram/ram.py
@@ -190,7 +190,8 @@ def execute_command(input_line: str):
         amount = int(args_dict["amount"])
         content = [sha256(i.to_bytes(1, byteorder='little')) for i in range(8)]
 
-        R_inst = manager.fund_instance(RAM(len(content)), amount, data=MerkleTree(content).root)
+        R = RAM(len(content))
+        R_inst = manager.fund_instance(R, amount, data=R.State(content))
 
         R_inst.data_expanded = content
 

--- a/examples/rps/rps.py
+++ b/examples/rps/rps.py
@@ -128,7 +128,7 @@ class AliceGame:
         print(f"Game result: {outcome}")
 
         self.env.prompt("Broadcasting adjudication transaction")
-        C2(outcome, m_a=m_a, m_b=m_b, r_a=r_a)
+        C2(outcome)(m_a=m_a, m_b=m_b, r_a=r_a)
 
         s.close()
 
@@ -178,7 +178,7 @@ class BobGame:
 
         self.env.prompt("Broadcasting Bob's move transaction")
 
-        [C2] = C("bob_move", signer=SchnorrSigner(self.priv_key), m_b=m_b)
+        [C2] = C("bob_move", SchnorrSigner(self.priv_key))(m_b=m_b)
 
         txid = C.spending_tx.hash
         print(f"Bob's move broadcasted: {m_b}. txid: {txid}")

--- a/examples/vault/vault.py
+++ b/examples/vault/vault.py
@@ -248,7 +248,7 @@ def execute_command(input_line: str):
         if not isinstance(instance.contract, (Vault, Unvaulting)):
             raise ValueError("Only Vault or Unvaulting instances can be recovered")
 
-        instance("recover", out_i=0)
+        instance("recover")(out_i=0)
 
     elif action == "withdraw":
         item_idx = int(args_dict["item"])

--- a/tests/test_ram.py
+++ b/tests/test_ram.py
@@ -9,7 +9,7 @@ from matt.merkle import MerkleTree
 AMOUNT = 20_000
 
 
-def test_withdraw(rpc, manager: ContractManager):
+def test_withdraw(manager: ContractManager):
     # tests the "withdraw" clause, that allows spending anywhere as long
     # as a valid Merkle proof is provided
     for size in [8, 16]:
@@ -27,11 +27,10 @@ def test_withdraw(rpc, manager: ContractManager):
                 )
             ]
 
-            out_instances = R_inst("withdraw",
-                                   outputs=outputs,
-                                   merkle_root=mt.root,
-                                   merkle_proof=mt.prove_leaf(leaf_index)
-                                   )
+            out_instances = R_inst("withdraw", outputs=outputs)(
+                merkle_root=mt.root,
+                merkle_proof=mt.prove_leaf(leaf_index)
+            )
 
             assert len(out_instances) == 0
 
@@ -48,11 +47,11 @@ def test_write(manager: ContractManager):
     R = RAM(len(data))
     R_inst = manager.fund_instance(R, AMOUNT, data=R.State(data))
 
-    out_instances = R_inst("write",
-                           merkle_root=mt.root,
-                           new_value=new_value,
-                           merkle_proof=mt.prove_leaf(leaf_index)
-                           )
+    out_instances = R_inst("write")(
+        merkle_root=mt.root,
+        new_value=new_value,
+        merkle_proof=mt.prove_leaf(leaf_index)
+    )
 
     assert len(out_instances) == 1
 
@@ -77,11 +76,11 @@ def test_write_loop(manager: ContractManager):
         leaf_index = i % size
         new_value = sha256((100 + i).to_bytes(1, byteorder='little'))
 
-        out_instances = R_inst("write",
-                               merkle_root=MerkleTree(data).root,
-                               new_value=new_value,
-                               merkle_proof=MerkleTree(data).prove_leaf(leaf_index)
-                               )
+        out_instances = R_inst("write")(
+            merkle_root=MerkleTree(data).root,
+            new_value=new_value,
+            merkle_proof=MerkleTree(data).prove_leaf(leaf_index)
+        )
 
         assert len(out_instances) == 1
 

--- a/tests/test_rps.py
+++ b/tests/test_rps.py
@@ -39,15 +39,15 @@ def test_rps(manager: ContractManager):
     # Bob's move
     m_b = moves["paper"]
 
-    [S1_inst] = S0_inst("bob_move", signer=bob_signer, m_b=m_b)
+    [S1_inst] = S0_inst("bob_move", bob_signer)(m_b=m_b)
 
     # cheating attempt
     with pytest.raises(JSONRPCException, match='Script failed an OP_EQUALVERIFY operation'):
-        S1_inst("alice_wins", m_a=m_a, m_b=m_b, r_a=r_a)
+        S1_inst("alice_wins")(m_a=m_a, m_b=m_b, r_a=r_a)
 
     # cheat a bit less
     with pytest.raises(JSONRPCException, match='Script failed an OP_EQUALVERIFY operation'):
-        S1_inst("tie", m_a=m_a, m_b=m_b, r_a=r_a)
+        S1_inst("tie")(m_a=m_a, m_b=m_b, r_a=r_a)
 
     # correct adjudication
-    S1_inst("bob_wins", m_a=m_a, m_b=m_b, r_a=r_a)
+    S1_inst("bob_wins")(m_a=m_a, m_b=m_b, r_a=r_a)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -53,7 +53,7 @@ def test_vault_recover(vault_specs: VaultSpecs, manager: ContractManager, report
 
     V_inst = manager.fund_instance(vault_contract, amount)
 
-    out_instances = V_inst("recover", out_i=0)
+    out_instances = V_inst("recover")(out_i=0)
 
     out: CTxOut = V_inst.spending_tx.vout[0]
 
@@ -69,8 +69,6 @@ def test_vault_recover(vault_specs: VaultSpecs, manager: ContractManager, report
 def test_vault_trigger_and_recover(vault_specs: VaultSpecs, manager: ContractManager, report):
     vault_description, vault_contract = vault_specs
 
-    signer = SchnorrSigner(unvault_priv_key)
-
     amount = 4999990000
 
     V_inst = manager.fund_instance(vault_contract, amount)
@@ -81,12 +79,14 @@ def test_vault_trigger_and_recover(vault_specs: VaultSpecs, manager: ContractMan
         ("bcrt1q6vqduw24yjjll6nfkxlfy2twwt52w58tnvnd46", 4999990000),
     ], nSequence=locktime)
 
-    [U_inst] = V_inst("trigger", signer=signer,
-                      out_i=0, ctv_hash=ctv_tmpl.get_standard_template_hash(0))
+    [U_inst] = V_inst("trigger", signer=SchnorrSigner(unvault_priv_key))(
+        out_i=0,
+        ctv_hash=ctv_tmpl.get_standard_template_hash(0)
+    )
 
     report.write(vault_description, format_tx_markdown(V_inst.spending_tx, "Trigger"))
 
-    out_instances = U_inst("recover", out_i=0)
+    out_instances = U_inst("recover")(out_i=0)
 
     assert len(out_instances) == 0
 
@@ -109,8 +109,10 @@ def test_vault_trigger_and_withdraw(vault_specs: VaultSpecs, rpc: AuthServicePro
         ("bcrt1q6vqduw24yjjll6nfkxlfy2twwt52w58tnvnd46", 1666663334),
     ], nSequence=locktime)
 
-    [U_inst] = V_inst("trigger", signer=signer,
-                      out_i=0, ctv_hash=ctv_tmpl.get_standard_template_hash(0))
+    [U_inst] = V_inst("trigger", signer=signer)(
+        out_i=0,
+        ctv_hash=ctv_tmpl.get_standard_template_hash(0)
+    )
 
     spend_tx, _ = manager.get_spend_tx(
         (U_inst, "withdraw", {"ctv_hash": ctv_tmpl.get_standard_template_hash(0)})


### PR DESCRIPTION
Refactors the method `__call__` of `ContractInstance` to guarantee a proper separation between the arguments `clause_name`, `signer` and `outputs` (which are instructions to the `ContractManager` from all the remaining arguments, that refer to the arguments of a clause during a state transition.

Also fixes a bug in the interactive RAM example.